### PR TITLE
ORION-11 hide launch configuration box

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/orion/widgets/nav/project-nav.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/widgets/nav/project-nav.js
@@ -435,6 +435,7 @@ define([
 			return deferred;
 		},
 		showViewMode: function(show) {
+			var show = false; // hack to hide the launch configuration bar since it is useless for palantir products.
 			var sidebar = this.sidebar;
 			var showing = !!sidebar.getViewMode(this.id);
 			if (showing === show) { return; }


### PR DESCRIPTION
This box is used for running applications through Cloud Foundry, which we don't
currently use in Palantir products.
