### PR TITLE
ORION-22 Change login link to point to oauth provider when appropriate

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/mixloginstatic/javascript/common.js
+++ b/bundles/org.eclipse.orion.client.ui/web/mixloginstatic/javascript/common.js
@@ -19,13 +19,23 @@ define(['orion/PageUtil', 'orion/xsrfUtils', 'orion/PageLinks', 'orion/xhr', './
       if (!hasClass(ele,cls)) ele.className += " "+cls;
     }
 
-    function redirectIfAuthProviderIsSet() {
-        xhr("POST", "../login/redirectinfo", { //$NON-NLS-0$
+    function getAuthProvider() {
+        return getRedirectInfo().then(function(result) {
+            return JSON.parse(result.response).AuthProvider;
+        });
+    }
+
+    function getRedirectInfo() {
+        return xhr("POST", "../login/redirectinfo", { //$NON-NLS-0$
             headers: {
                 "Orion-Version": "1" //$NON-NLS-0$
             },
             timeout: 15000
-        }).then(function(result) {
+        });
+    }
+
+    function redirectIfAuthProviderIsSet() {
+        getRedirectInfo().then(function(result) {
             var authProvider = JSON.parse(result.response).AuthProvider;
             if (authProvider) {
                 window.location = "../login/oauth?oauth=" + authProvider; //$NON-NLS-0$
@@ -393,6 +403,7 @@ define(['orion/PageUtil', 'orion/xsrfUtils', 'orion/PageLinks', 'orion/xhr', './
         confirmLogin: confirmLogin,
         createOAuthLink: createOAuthLink,
         decodeBase64: decodeBase64,
+        getAuthProvider: getAuthProvider,
         getParam: getParam,
         getRedirect: getRedirect,
         passwordSwitcher: passwordSwitcher,

--- a/bundles/org.eclipse.orion.client.ui/web/plugins/orionPlugin.js
+++ b/bundles/org.eclipse.orion.client.ui/web/plugins/orionPlugin.js
@@ -11,9 +11,10 @@
 
 /*eslint-env browser, amd*/
 define([
-	"orion/plugin", 
-	"plugins/fileClientPlugin",
+	"orion/plugin",
+	"../mixloginstatic/javascript/common",
 	"plugins/authenticationPlugin",
+	"plugins/fileClientPlugin",
 	"plugins/jslintPlugin",
 	"plugins/googleAnalyticsPlugin",
 	"plugins/languageToolsPlugin",
@@ -23,23 +24,30 @@ define([
 	"plugins/webEditingPlugin",
 	"profile/userservicePlugin",
 	"plugins/helpPlugin"
-], function(PluginProvider) {
-	
+], function(PluginProvider, common) {
 	var plugins = Array.prototype.slice.call(arguments);
-	plugins.shift();
+	plugins.shift(); // skip plugin
+	plugins.shift(); // skip common
 
 	function connect(pluginProvider) {
-		var login = new URL("../mixloginstatic/LoginWindow.html", self.location.href).href;
-		var headers = {
-			name: "Orion Core Support",
-			version: "1.0",
-			description: "This plug-in provides the core Orion support.",
-			login: login
-		};
-		pluginProvider = pluginProvider || new PluginProvider();
-		pluginProvider.updateHeaders(headers);
-		registerServiceProviders(pluginProvider);
-		pluginProvider.connect();
+		common.getAuthProvider().then(function(provider) {
+			if (provider) {
+				var login = new URL("../login/oauth?oauth=" + provider, self.location.href).href;
+			} else {
+				var login = new URL("../mixloginstatic/LoginWindow.html", self.location.href).href;
+			}
+
+			var headers = {
+				name: "Orion Core Support",
+				version: "1.0",
+				description: "This plug-in provides the core Orion support.",
+				login: login
+			};
+			pluginProvider = pluginProvider || new PluginProvider();
+			pluginProvider.updateHeaders(headers);
+			registerServiceProviders(pluginProvider);
+			pluginProvider.connect();
+		});
 	}
 
 	function registerServiceProviders(provider) {


### PR DESCRIPTION
Before, when users' sessions timed out, they would always be directed
to the static login page to log back in. Now they will be directed
there only if the oauth provider is not set, and to the oauth provider
if it is specified.
