### PR TITLE
ORION-21 Disable auto-save by default

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/orion/editorPreferences.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/editorPreferences.js
@@ -18,7 +18,7 @@ define([
 	var SETTINGS_KEY = "editorSettings"; //$NON-NLS-0$
 
 	var defaults = {
-		autoSave: true,
+		autoSave: false,
 		autoSaveVisible: true,
 		autoSaveLocalVisible: true,
 		autoSaveTimeout: 250,


### PR DESCRIPTION
Auto-save is still available, but will be defaulted to off.
