### PR TITLE
ORION-81/83 sidebar and overview updated after linking/importing a project

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/orion/fileCommands.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/fileCommands.js
@@ -1054,8 +1054,9 @@ define(['i18n!orion/navigate/nls/messages', 'orion/webui/littlelib', 'orion/i18n
 		var createProjectFunction = function(name, path) {
 			var deferred = fileClient.createProject(getWorkspaceLocation(), name, path, true);
 			progressService.showWhile(deferred, i18nUtil.formatMessage(messages["Linking to ${0}"], path)).then(function(newFolder) {
-				dispatchModelEventOn({type: "create", parent: explorer.treeRoot, newValue: newFolder }); //$NON-NLS-0$
-				window.location.href = require.toUrl("edit/edit.html") +"#" + newFolder.ContentLocation;
+				return fileClient.read(newFolder.ContentLocation, true);
+			}, errorHandler).then(function(folderDetails) {
+				dispatchModelEventOn({type: "create", parent: explorer.treeRoot, newValue: folderDetails});
 			}, errorHandler);
 		};
 		

--- a/bundles/org.eclipse.orion.client.ui/web/orion/projectCommands.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/projectCommands.js
@@ -1178,8 +1178,6 @@ define(['require', 'i18n!orion/navigate/nls/messages', 'orion/webui/littlelib', 
 						}
 						progress.showWhile(handler.initProject(params, {WorkspaceLocation: item.Location}), actionComment).then(function(project){
 							dispatchNewProject(item, project);
-							window.location.href = require.toUrl("edit/edit.html") + "#" + project.ContentLocation;
-							window.location.reload();
 						}, function(error){
 							if(error.Retry && error.Retry.addParameters){
 								var options = {

--- a/bundles/org.eclipse.orion.client.ui/web/orion/widgets/nav/project-nav.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/widgets/nav/project-nav.js
@@ -347,7 +347,9 @@ define([
 			sidebar.sidebarNavInputManager.addEventListener("projectDisplayed", handleDisplay); //$NON-NLS-0$
 		}
 		this.editorInputManager.addEventListener("InputChanged", function(event) { //$NON-NLS-0$
-			if (!sidebar.getActiveViewModeId()){
+			_self.lastCheckedLocation = event.metadata.Location;
+			_self.showViewMode(false);
+			if (!sidebar.getActiveViewModeId()) {
 				sidebar.setViewMode(sidebar.getNavigationViewMode().id);
 			}
 		});


### PR DESCRIPTION
Details:
- Event listener for "inputChanged" fixed
- Unified event creation after linking and importing
- Work-around with page reloading erased

Change-Id: I4665adc17baf30b3c9155de2383e4c8bd1838f57
