### PR TITLE
ORION-86: Persist saved author name and email

### DIFF
--- a/bundles/org.eclipse.orion.client.git/web/orion/git/logic/gitCommit.js
+++ b/bundles/org.eclipse.orion.client.git/web/orion/git/logic/gitCommit.js
@@ -50,7 +50,7 @@ function(messages, Deferred, mGitCommon, i18nUtil) {
 						if(config.Children[i].Key===key){
 							found = true;
 							var locationToUpdate = config.Children[i].Location;
-							gitService.editCloneConfigurationProperty(locationToUpdate,value).then(deferred.resolve, deferred.reject);
+							gitService.editCloneConfigurationProperty(locationToUpdate,[value]).then(deferred.resolve, deferred.reject);
 							break;
 						}
 					}


### PR DESCRIPTION
-- The backend (GitConfigHandlerV1.java) expects an
   array (toPut.optJSONArray) for any git config
   properties to be updated. This is to handle
   the cases of multiple things (for example refs).
-- Modified gitCommit.js so that the correct calls
   are made; instead of passing in a string, pass
   in a singleton array
-- Note that only the committer's name can be
   persisted (as evidenced by the check mark beside
   the corresponding option). By default, the author's
   name and email will always be the committer's name
   (user.name and user.email from the .git/CONFIG)
