### PR TITLE
ORION-55: config points - minor fix and cleanup

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/plugins/orionPlugin.js
+++ b/bundles/org.eclipse.orion.client.ui/web/plugins/orionPlugin.js
@@ -43,9 +43,7 @@ define([
 			pluginProvider = pluginProvider || new PluginProvider();
 			pluginProvider.updateHeaders(headers);
 			var registerPromise = registerServiceProviders(pluginProvider);
-			registerPromise.then(function() {
-				pluginProvider.connect();
-			});
+			registerPromise.then(pluginProvider.connect);
 		});
 	}
 
@@ -60,7 +58,7 @@ define([
 		// lazy evaluation of promises, i.e. do not short circuit to 
 		// a failure if any one of the promise fails. We still want
 		// to connect to the other providers
-		return Deferred.all(promises, function(e) { console.log(e); });
+		return Deferred.all(promises, console.log);
 	}
 
 	return {

--- a/bundles/org.eclipse.orion.client.ui/web/plugins/pageLinksPlugin.js
+++ b/bundles/org.eclipse.orion.client.ui/web/plugins/pageLinksPlugin.js
@@ -34,7 +34,7 @@ define([
 
 	function getEnableShell() {
 		var EXE_KEY = "plugin.execution.enabled"
-		return xhr("POST", "/config", {
+		return xhr("POST", "../config", {
 			headers: {
 				"Orion-Version": "1"
 			},


### PR DESCRIPTION
If we want to support context paths we need to
use '../config' for the POST request.

Change-Id: I7362e9c71b547a236c3b2c2d70396426c6480862
