### PR TITLE
ORION-70: Add console to the editor.

### DIFF
--- a/bundles/org.eclipse.orion.client.ui/web/css/layout_common.css
+++ b/bundles/org.eclipse.orion.client.ui/web/css/layout_common.css
@@ -365,6 +365,17 @@ hard-coded numbers elsewhere.
 	padding-left: 5px;
 }
 
+.editorViewerHeaderAction {
+	position: absolute;
+	right: 2px;
+	top: 3px;
+}
+
+button.editorViewerHeaderAction {
+	line-height: 20px;
+	padding-bottom: 0;
+}
+
 .editorViewerContent {
 	position: absolute;
 	width: 100%;
@@ -404,7 +415,7 @@ hard-coded numbers elsewhere.
  */
 .splitVerticalLayout {
 	position: absolute;
-	top: 33%;  /* override this value if you want a different proportion of the two split panes */
+	top: 70%;  /* override this value if you want a different proportion of the two split panes */
 	width: 100%;
 	z-index: 51;
 	height: 3px;
@@ -435,7 +446,7 @@ and (max-device-width : 1024px)  {
 	 */
 	.splitVerticalLayout {
 		position: absolute;
-		top: 33%;  /* override this value if you want a different proportion of the two split panes */
+		top: 70%;  /* override this value if you want a different proportion of the two split panes */
 		width: 100%;
 		z-index: 50;
 		height: 20px;
@@ -838,4 +849,3 @@ and (max-device-width : 1024px)  {
 	position:relative;
 	top:-6px;
 }
-

--- a/bundles/org.eclipse.orion.client.ui/web/edit/common.css
+++ b/bundles/org.eclipse.orion.client.ui/web/edit/common.css
@@ -6,6 +6,8 @@
 
 @import "../css/sections.css"; /* for outliner */
 
+@import "../orion/console/console.css";
+
 @import "../orion/editor/editor.css";
 
 @import "../orion/webui/Slideout.css";

--- a/bundles/org.eclipse.orion.client.ui/web/edit/edit.html
+++ b/bundles/org.eclipse.orion.client.ui/web/edit/edit.html
@@ -30,12 +30,21 @@
 						<div id="sidebar" class="dropdownTrigger toolbarTarget sidebar"></div>
 					</div>
 				</div>
-				<div class="split splitLayout" style="left: 25%;"></div>
-				<div id="rightPane" class="mainpane mainPanelLayout hasSplit">
-					<div class="fixedToolbarHolder">
-						<div id="editor" class="workingTarget"></div>
-						<div id="replaceCompareTitleDiv" class="replaceCompareTitleDiv"></div>
-						<div id="replaceCompareDiv" class="replaceCompareDiv workingTarget"></div>
+				<div class="split splitLayout"></div>
+				<div id="rightPane" class="mainPanelLayout hasSplit">
+					<div id="topPane" class="mainpane topPanelLayout hasSplit">
+						<div class="fixedToolbarHolder">
+							<div id="editor" class="workingTarget"></div>
+							<div id="replaceCompareTitleDiv" class="replaceCompareTitleDiv"></div>
+							<div id="replaceCompareDiv" class="replaceCompareDiv workingTarget"></div>
+						</div>
+					</div>
+					<div class="splitEditConsole splitLayout" data-initial-state="closed"></div>
+					<div id="bottomPane" class="auxpane botPanelLayout hasSplit">
+						<div id="console">
+							<div class="clear-console">Clear</div>
+							<ul class="console-messages"></ul>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/bundles/org.eclipse.orion.client.ui/web/edit/setup.js
+++ b/bundles/org.eclipse.orion.client.ui/web/edit/setup.js
@@ -47,13 +47,15 @@ define([
 	'orion/Deferred',
 	'orion/projectClient',
 	'orion/webui/splitter',
-	'orion/webui/tooltip'
+	'orion/webui/tooltip',
+	'orion/console/console',
+	'orion/exe/python/runDoctest'
 ], function(
 	messages, Sidebar, mInputManager, mCommands, mGlobalCommands,
 	mTextModel, mUndoStack,
 	mFolderView, mEditorView, mPluginEditorView , mMarkdownView, mMarkdownEditor,
 	mCommandRegistry, mContentTypes, mFileClient, mFileCommands, mEditorCommands, mSelection, mStatus, mProgress, mOperationsClient, mOutliner, mDialogs, mExtensionCommands, ProjectCommands, mSearchClient,
-	EventTarget, URITemplate, i18nUtil, PageUtil, objects, lib, Deferred, mProjectClient, mSplitter, mTooltip
+	EventTarget, URITemplate, i18nUtil, PageUtil, objects, lib, Deferred, mProjectClient, mSplitter, mTooltip, mConsole, mRunDoctest
 ) {
 
 var exports = {};
@@ -740,6 +742,22 @@ objects.mixin(EditorSetup.prototype, {
 				break;
 		}
 	},
+
+	createConsole: function() {
+		var console = new mConsole.Console({
+			inputManager: this.activeEditorViewer.inputManager,
+			serviceRegistry: this.serviceRegistry
+		});
+		this.serviceRegistry.registerService("orion.console", console, {});
+	},
+
+	createExe: function() {
+		var exe = new mRunDoctest.RunDoctest({
+			inputManager: this.activeEditorViewer.inputManager,
+			serviceRegistry: this.serviceRegistry,
+			sidebarNavInputManager: this.sidebarNavInputManager
+		});
+	},
 	
 	createEditorViewer: function(id) {
 		var editorViewer = new EditorViewer({
@@ -1049,6 +1067,8 @@ exports.setUpEditor = function(serviceRegistry, pluginRegistry, preferences, rea
 			setup.createSideBar();
 			setup.editorViewers.push(setup.createEditorViewer());
 			setup.setActiveEditorViewer(setup.editorViewers[0]);
+			setup.createConsole();
+			setup.createExe();
 			if (enableSplitEditor) {
 				setup.createSplitMenu();
 				setup.setSplitterMode(MODE_SINGLE);

--- a/bundles/org.eclipse.orion.client.ui/web/orion/console/console.css
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/console/console.css
@@ -1,0 +1,47 @@
+#console {
+	background: white;
+	color: #8a9ba8;
+	height: 100%;
+	overflow: auto;
+	position: absolute;
+	width: 100%;
+}
+
+.clear-console {
+	cursor: pointer;
+	display: inline-block;
+	line-height: 22px;
+	position: fixed;
+	right: 5px;
+	text-decoration: underline;
+}
+
+.console-arrow {
+	display: inline-block;
+	left: -16px;
+	position: absolute;
+	top: 2px;
+}
+
+.console-message {
+	padding: 5px 0;
+	position: relative;
+	white-space: pre;
+}
+
+.console-message .core-sprite-closedarrow, .console-message .core-sprite-openarrow {
+	cursor: pointer;
+}
+
+.console-message .core-sprite-closedarrow:hover, .console-message .core-sprite-openarrow:hover {
+	color: #00AED1;
+}
+
+.console-messages {
+	font-family: monospace;
+	list-style-type: none;
+	margin: 0;
+	overflow: scroll;
+	padding-left: 20px;
+	padding-right: 40px;
+}

--- a/bundles/org.eclipse.orion.client.ui/web/orion/console/console.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/console/console.js
@@ -1,0 +1,95 @@
+/**
+ * A general console acting as stdout to the user.
+ */
+
+/*eslint-env browser, amd*/
+define(['orion/webui/littlelib', 'orion/webui/splitter'], function(lib, mSplitter) {
+
+	function Console(options) {
+		var splitEditConsole = lib.$(".splitEditConsole"); //$NON-NLS-0$
+		var top = lib.$(".topPanelLayout"); //$NON-NLS-0$
+		var bot = lib.$(".botPanelLayout"); //$NON-NLS-0$
+		this.splitter = new mSplitter.Splitter({
+			id: "editConsole", //$NON-NLS-0$
+			node: splitEditConsole,
+			sidePanel: top,
+			mainPanel: bot,
+			vertical: true,
+			toggle: true,
+			closeReversely: true,
+			closeByDefault: true
+		});
+
+		this.console = lib.node("console"); //$NON-NLS-0$
+		this.contentsNode = lib.$(".console-messages", this.console); //$NON-NLS-0$
+		this.inputManager = options.inputManager;
+		this.serviceRegistry = options.serviceRegistry;
+		lib.$(".clear-console").onclick = this.clearContent.bind(this); //$NON-NLS-0$
+		this.clearContent();
+	}
+
+	Console.prototype = {
+		clearContent: function() {
+			this.contentsNode.innerHTML = ""; //$NON-NLS-0$
+		},
+
+		createContent: function(content) {
+			this.show();
+			var contentItem = document.createElement("li"); //$NON-NLS-0$
+			contentItem.classList.add("console-message"); //$NON-NLS-0$
+			var coreSpriteArrow = document.createElement("div"); //$NON-NLS-0$
+			coreSpriteArrow.classList.add("console-arrow"); //$NON-NLS-0$
+			var contentExpandedWrapper = document.createElement("div"); //$NON-NLS-0$
+			var contentCollapsedWrapper = document.createElement("div"); //$NON-NLS-0$
+			contentExpandedWrapper.appendChild(document.createTextNode(content));
+			contentCollapsedWrapper.appendChild(document.createTextNode(content.split("\n")[0])); //$NON-NLS-0$
+			contentItem.appendChild(coreSpriteArrow);
+			contentItem.appendChild(contentExpandedWrapper);
+			contentItem.appendChild(contentCollapsedWrapper);
+			this.contentsNode.appendChild(contentItem);
+
+			var expand = function() {
+				coreSpriteArrow.classList.remove("core-sprite-closedarrow"); //$NON-NLS-0$
+				coreSpriteArrow.classList.add("core-sprite-openarrow"); //$NON-NLS-0$
+				contentExpandedWrapper.style.display = "block"; //$NON-NLS-0$
+				contentCollapsedWrapper.style.display = "none"; //$NON-NLS-0$
+				return collapse;
+			};
+
+			var collapse = function() {
+				coreSpriteArrow.classList.remove("core-sprite-openarrow"); //$NON-NLS-0$
+				coreSpriteArrow.classList.add("core-sprite-closedarrow"); //$NON-NLS-0$
+				contentCollapsedWrapper.style.display = "block"; //$NON-NLS-0$
+				contentExpandedWrapper.style.display = "none"; //$NON-NLS-0$
+				return expand;
+			}
+
+			var current = expand;
+			var toggle = function() {
+				current = current();
+			};
+
+			// expanded by default
+			toggle();
+			coreSpriteArrow.onclick = toggle;
+
+			var scrollTop = this.contentsNode.offsetHeight - this.console.offsetHeight;
+			if (scrollTop > 0) {
+				this.console.scrollTop = scrollTop;
+			}
+		},
+
+		hide: function() {
+			if (!this.splitter.isClosed()) {
+				this.splitter.toggleSidePanel();
+			}
+		},
+		show: function() {
+			if (this.splitter.isClosed()) {
+				this.splitter.toggleSidePanel();
+			}
+		}
+	}
+
+	return {Console: Console};
+});

--- a/bundles/org.eclipse.orion.client.ui/web/orion/exe/python/runDoctest.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/exe/python/runDoctest.js
@@ -1,0 +1,87 @@
+/**
+ * This adds a "Run Tests" element to the editor and plugs into the console to output the tests' doctest output.
+ */
+
+/*eslint-env browser, amd*/
+define(["orion/xhr", "orion/plugin", "orion/webui/littlelib", "domReady!"], function(xhr, PluginProvider, lib) {
+
+	function RunDoctest(options) {
+		this.inputManager = options.inputManager;
+		this.console = options.serviceRegistry.getService("orion.console"); //$NON-NLS-0$
+		this.exe = options.serviceRegistry.getService("orion.exe"); //$NON-NLS-0$
+
+		var exeBar = lib.$(".editorViewerHeader"); //$NON-NLS-0$
+
+		// cancel
+		var cancelButton = this.cancelButton = document.createElement("button"); //$NON-NLS-0$
+		cancelButton.classList.add("editorViewerHeaderAction"); //$NON-NLS-0$
+		cancelButton.classList.add("dropdownTrigger"); //$NON-NLS-0$
+		cancelButton.classList.add("commandImage"); //$NON-NLS-0$
+		cancelButton.classList.add("orionButton"); //$NON-NLS-0$
+		this.hideCancel();
+		cancelButton.onclick = this.cancel.bind(this);
+		cancelButton.appendChild(document.createTextNode("Cancel"));
+
+		// run
+		var runTestsButton = this.runTestsButton = document.createElement("button"); //$NON-NLS-0$
+		runTestsButton.classList.add("editorViewerHeaderAction"); //$NON-NLS-0$
+		runTestsButton.classList.add("dropdownTrigger"); //$NON-NLS-0$
+		runTestsButton.classList.add("commandImage"); //$NON-NLS-0$
+		runTestsButton.classList.add("orionButton"); //$NON-NLS-0$
+		this.hideRunTests();
+		runTestsButton.onclick = this.run.bind(this);
+		runTestsButton.appendChild(document.createTextNode("Run Tests"));
+
+		exeBar.appendChild(cancelButton);
+		exeBar.appendChild(runTestsButton);
+
+		options.sidebarNavInputManager.addEventListener("selectionChanged", function(event) { //$NON-NLS-0$
+			if (event.selections.length === 1 && event.selection["Directory"] === false && //$NON-NLS-0$
+				this.inputManager._input.match("\\.py$") != null) { //$NON-NLS-0$
+				this.showRunTests();
+			} else {
+				this.console.hide();
+				this.hideRunTests();
+			}
+			this.hideCancel();
+		}.bind(this));
+	};
+
+	RunDoctest.prototype = {
+		hideCancel: function() {
+			this.cancelButton.style.display = "none"; //$NON-NLS-0$
+		},
+		showCancel: function() {
+			this.cancelButton.style.display = "block"; //$NON-NLS-0$
+		},
+		hideRunTests: function() {
+			this.runTestsButton.style.display = "none"; //$NON-NLS-0$
+		},
+		showRunTests: function() {
+			this.runTestsButton.style.display = "block"; //$NON-NLS-0$
+		},
+		cancel: function() {
+			this.exe.getExeResult("cancel", this.inputManager._input); //$NON-NLS-0$
+			this.hideCancel();
+			this.showRunTests();
+		},
+		run: function() {
+			this.hideRunTests();
+			this.showCancel();
+			this.exe.getExeResult("doctest", this.inputManager._input).then(function(result) { //$NON-NLS-0$
+				this.writeToConsole(result)
+				this.hideCancel();
+				this.showRunTests();
+			}.bind(this)); //$NON-NLS-0$
+		},
+		writeToConsole: function(result) {
+			if (result) {
+				this.console.createContent(result);
+			}
+		}
+	};
+
+	return {
+		RunDoctest: RunDoctest
+	};
+})

--- a/bundles/org.eclipse.orion.client.ui/web/orion/exe/python/runDoctest.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/exe/python/runDoctest.js
@@ -6,6 +6,7 @@
 define(["orion/xhr", "orion/plugin", "orion/webui/littlelib", "domReady!"], function(xhr, PluginProvider, lib) {
 
 	function RunDoctest(options) {
+		this.running = false;
 		this.inputManager = options.inputManager;
 		this.console = options.serviceRegistry.getService("orion.console"); //$NON-NLS-0$
 		this.exe = options.serviceRegistry.getService("orion.exe"); //$NON-NLS-0$
@@ -36,6 +37,10 @@ define(["orion/xhr", "orion/plugin", "orion/webui/littlelib", "domReady!"], func
 		exeBar.appendChild(runTestsButton);
 
 		options.sidebarNavInputManager.addEventListener("selectionChanged", function(event) { //$NON-NLS-0$
+			if (this.running) {
+				alert("Warning: You are navigating away from a test that has not yet completed which may cause problems. To cancel this test, simply start another test.");
+				this.running = false;
+			}
 			if (event.selections.length === 1 && event.selection["Directory"] === false && //$NON-NLS-0$
 				this.inputManager._input.match("\\.py$") != null) { //$NON-NLS-0$
 				this.showRunTests();
@@ -68,7 +73,9 @@ define(["orion/xhr", "orion/plugin", "orion/webui/littlelib", "domReady!"], func
 		run: function() {
 			this.hideRunTests();
 			this.showCancel();
+			this.running = true;
 			this.exe.getExeResult("doctest", this.inputManager._input).then(function(result) { //$NON-NLS-0$
+				this.running = false;
 				this.writeToConsole(result)
 				this.hideCancel();
 				this.showRunTests();

--- a/bundles/org.eclipse.orion.client.ui/web/orion/globalCommands.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/globalCommands.js
@@ -688,6 +688,7 @@ define([
 					main: main
 				};
 				mainSplitter.splitter = new mSplitter.Splitter({
+					id: "navEdit",
 					node: splitNode,
 					sidePanel: side,
 					mainPanel: main,

--- a/bundles/org.eclipse.orion.client.ui/web/orion/webui/splitter.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/webui/splitter.js
@@ -46,10 +46,12 @@ define([
 	 * @param {Element} options.node The node for the splitter presentation.  Required.
 	 * @param {Element} options.sidePanel The node for the side (toggling) panel.  Required.
 	 * @param {Element} options.mainPanel The node for the main panel.  Required.
+	 * @param {String} [options.id=""] Specifies an id for this splitter. Should be unique among all splitters on the page.
 	 * @param {Boolean} [options.toggle=false] Specifies that the side node should be able to toggle.
 	 * @param {Boolean} [options.vertical=false] Specifies that the nodes are stacked vertically rather than horizontal.
 	 * @param {Boolean} [options.closeReversely=false] Specifies that the splitter moves to right when nodes are stacked horizontally, or to bottom when nodes are stacked vertically.
 	 * @param {Boolean} [options.proportional=false] Specifies that the splitter is proportional so that growing the browser allocates space to both nodes.
+	 * @param {Boolean} [options.closeByDefault=false] Specifies that the side node should be toggled off by default.
 	 *
 	 * @borrows orion.editor.EventTarget#addEventListener as #addEventListener
 	 * @borrows orion.editor.EventTarget#removeEventListener as #removeEventListener
@@ -73,8 +75,9 @@ define([
 			this._animationDelay = 501;  // longer than CSS transitions in layout.css
 			this._collapseTrailing = options.closeReversely || false;
 			this._proportional = options.proportional || false;
+			this._closeByDefault = options.closeByDefault || false;
 
-			this._prefix = "/orion/splitter/" + (this.$splitter.id || document.body.id || "");  //$NON-NLS-0$
+			this._prefix = "/orion/splitter/" + (options.id || this.$splitter.id || document.body.id || "");  //$NON-NLS-0$
 			
 			if (options.toggle) {
 				this._thumb = document.createElement("div"); //$NON-NLS-0$
@@ -249,7 +252,7 @@ define([
 		/**
 		 * Close the side panel.  This function has no effect if the side panel is already closed.
 		 */
-		openSidePanel: function() {
+		closeSidePanel: function() {
 			if (!this._closed) {
 				this._thumbDown();
 			}

--- a/bundles/org.eclipse.orion.client.ui/web/plugins/orionPlugin.js
+++ b/bundles/org.eclipse.orion.client.ui/web/plugins/orionPlugin.js
@@ -24,8 +24,7 @@ define([
 	"plugins/taskPlugin",
 	"plugins/webEditingPlugin",
 	"profile/userservicePlugin",
-	"plugins/helpPlugin",
-	"shell/plugins/shellPagePlugin"
+	"plugins/helpPlugin"
 ], function(Deferred, PluginProvider, common) {
 	var plugins = Array.prototype.slice.call(arguments);
 	plugins.shift(); // skip Deferred

--- a/bundles/org.eclipse.orion.client.ui/web/plugins/pageLinksPlugin.js
+++ b/bundles/org.eclipse.orion.client.ui/web/plugins/pageLinksPlugin.js
@@ -11,13 +11,12 @@
  *******************************************************************************/
 /*eslint-env browser, amd*/
 define([
-	'orion/xhr',
 	'orion/PageLinks',
 	'orion/plugin',
 	'orion/URITemplate',
 	'i18n!orion/nls/messages',
 	'i18n!orion/widgets/nls/messages'
-], function(xhr, PageLinks, PluginProvider, URITemplate, messages, widgetMessages) {
+], function(PageLinks, PluginProvider, URITemplate, messages, widgetMessages) {
 	
 	function connect() {
 		var headers = {
@@ -32,23 +31,6 @@ define([
 		});
 	}
 
-	function getEnableShell() {
-		var EXE_KEY = "plugin.execution.enabled"
-		return xhr("POST", "../config", {
-			headers: {
-				"Orion-Version": "1"
-			},
-			data: JSON.stringify({
-				"configKeys": [EXE_KEY]
-			}),
-			timeout: 15000,
-			log: false
-		}).then(function(result) {
-			var resultJson = JSON.parse(result.response);
-			return resultJson[EXE_KEY];
-		});
-	}
-
 	function registerServiceProviders(provider) {
 		var serviceImpl = { /* All data is in properties */ };
 	
@@ -59,17 +41,6 @@ define([
 			nls: "orion/nls/messages",
 			imageClass: "core-sprite-edit",
 			order: 10
-		});
-		var result = getEnableShell().then(function(shouldEnable) {
-			if (shouldEnable === "true") {
-				provider.registerService("orion.page.link.category", null, {		
-					id: "shell",		
-					name: messages["Shell"],		
-					nls: "orion/nls/messages",		
-					imageClass: "core-sprite-shell",		
-					order: 40
-				});
-			}
 		});
 		provider.registerService("orion.page.link.category", null, {
 			id: "settings",
@@ -234,7 +205,6 @@ define([
 				OrionHome: PageLinks.getOrionHome()
 			}))
 		});
-		return result;
 	}
 
 	return {


### PR DESCRIPTION
QE: Please test the following:
1. The "Run Tests" option only appears if the current file is a python file
2. The "Run Tests" option, when clicked, changes the option to "Cancel".
3. When the tests have finished running, the console pops up with the
   test output. Note that if the console is already open this doesn't
   have any effect. Also note that if the tests take forever, the
   console doesn't pop up until "Cancel" is clicked.
4. The console can be opened and closed as usual.
5. Refreshing the page persists console opened/closed state but does not
   persist console logs.
6. The "Clear" option clears the console when clicked.
7. Any misc edge cases.

CRR: vchu, mwlodarczyk
