### PR TITLE
ORION-109: Integrate commit hook into console

### DIFF
--- a/bundles/org.eclipse.orion.client.git/web/git/git-repository.css
+++ b/bundles/org.eclipse.orion.client.git/web/git/git-repository.css
@@ -8,6 +8,8 @@
 
 @import "../orion/compare/compareView.css";
 
+@import "../orion/console/console.css";
+
 @import "css/git.css";
 
 @import "../css/theme.css";

--- a/bundles/org.eclipse.orion.client.git/web/git/git-repository.html
+++ b/bundles/org.eclipse.orion.client.git/web/git/git-repository.html
@@ -27,9 +27,18 @@
 					</div>
 				</div>
 				<div class="split splitLayout"></div>
-				<div id="rightPane" class="mainpane mainPanelLayout hasSplit">
-					<div class="fixedToolbarHolder">
-						<div id="table" class="workingTarget"></div>
+				<div id="rightPane" class="mainPanelLayout hasSplit">
+					<div id="topPane" class="mainpane topPanelLayout hasSplit">
+						<div class="fixedToolbarHolder">
+							<div id="table" class="workingTarget"></div>
+						</div>
+					</div>
+					<div class="splitEditConsole splitLayout" data-initial-state="closed"></div>
+					<div id="bottomPane" class="auxpane botPanelLayout hasSplit">
+						<div id="console">
+							<div class="clear-console">Clear</div>
+							<ul class="console-messages"></ul>
+						</div>
 					</div>
 				</div>
 			</div>

--- a/bundles/org.eclipse.orion.client.git/web/git/git-repository.js
+++ b/bundles/org.eclipse.orion.client.git/web/git/git-repository.js
@@ -29,7 +29,8 @@ define([
 	'orion/git/gitClient',
 	'orion/ssh/sshTools',
 	'orion/fileUtils',
-	'orion/links'
+	'orion/links',
+	'orion/console/console'
 ], function(
 	mBrowserCompatibility,
 	messages,
@@ -49,7 +50,8 @@ define([
 	mGitClient,
 	mSshTools,
 	mFileUtils,
-	mLinks
+	mLinks,
+	mConsole
 ) {
 
 mBootstrap.startup().then(function(core) {
@@ -67,6 +69,9 @@ mBootstrap.startup().then(function(core) {
 	var gitClient = new mGitClient.GitService(serviceRegistry);
 	var fileClient = new mFileClient.FileClient(serviceRegistry);
 	var searcher = new mSearchClient.Searcher({serviceRegistry: serviceRegistry, commandService: commandRegistry, fileService: fileClient});
+	new mConsole.Console({
+		serviceRegistry: serviceRegistry
+	});
 	
 	var explorer = new mGitRepositoryExplorer.GitRepositoryExplorer({
 		parentId: "artifacts", //$NON-NLS-0$

--- a/bundles/org.eclipse.orion.client.git/web/orion/git/logic/gitPush.js
+++ b/bundles/org.eclipse.orion.client.git/web/orion/git/logic/gitPush.js
@@ -175,7 +175,7 @@ define([
 												}
 											}
 											if (jsonData.Message) {
-												display.Message += ".</br></br>Remote responded with: " + jsonData.Message;
+												serviceRegistry.getService("orion.console").createContent("Remote responded with: " + jsonData.Message); //$NON-NLS-0$
 											}
 										}
 										serviceRegistry.getService("orion.page.message").setProgressResult(display); //$NON-NLS-0$

--- a/bundles/org.eclipse.orion.client.ui/web/edit/setup.js
+++ b/bundles/org.eclipse.orion.client.ui/web/edit/setup.js
@@ -744,11 +744,9 @@ objects.mixin(EditorSetup.prototype, {
 	},
 
 	createConsole: function() {
-		var console = new mConsole.Console({
-			inputManager: this.activeEditorViewer.inputManager,
+		new mConsole.Console({
 			serviceRegistry: this.serviceRegistry
 		});
-		this.serviceRegistry.registerService("orion.console", console, {});
 	},
 
 	createExe: function() {

--- a/bundles/org.eclipse.orion.client.ui/web/orion/console/console.js
+++ b/bundles/org.eclipse.orion.client.ui/web/orion/console/console.js
@@ -22,8 +22,7 @@ define(['orion/webui/littlelib', 'orion/webui/splitter'], function(lib, mSplitte
 
 		this.console = lib.node("console"); //$NON-NLS-0$
 		this.contentsNode = lib.$(".console-messages", this.console); //$NON-NLS-0$
-		this.inputManager = options.inputManager;
-		this.serviceRegistry = options.serviceRegistry;
+		options.serviceRegistry.registerService("orion.console", this); //$NON-NLS-0$
 		lib.$(".clear-console").onclick = this.clearContent.bind(this); //$NON-NLS-0$
 		this.clearContent();
 	}


### PR DESCRIPTION
-- Did some minor refactor of the console service
   to allow the git plugin to also use it. This
   is similar to how StatusReportingService is
   used, for example.
-- This commit reverts ORION-79 and instead
   displays the message in the console.
-- Similar semantics to the editor console apply
   (clear, pops up when content is added etc)
