### PR TITLE
ORION-108: Support https

### DIFF
--- a/bundles/org.eclipse.orion.client.git/web/git/plugins/gitPlugin.js
+++ b/bundles/org.eclipse.orion.client.git/web/git/plugins/gitPlugin.js
@@ -402,7 +402,7 @@ define([
 			return gitUrl;
 		}
 	
-		provider.registerService("orion.project.handler", {
+		var gitProjectHandlerImpl = {
 			paramsToDependencyDescription: function(params){
 				return {Type: "git", Location: removeUserInformation(params.url)};
 			},
@@ -463,10 +463,6 @@ define([
 								return;
 							} 
 							if(error.JsonData.Host){
-								error.Retry = {
-									addParameters : [{id: "sshuser", type: "text", name:  gitmessages["User Name:"]}, {id: "sshpassword", type: "password", name:  gitmessages["Password:"]}],
-									optionalParameters: [{id: "sshprivateKey", type: "textarea", name:  gitmessages["Ssh Private Key:"]}, {id: "sshpassphrase", type: "password", name:  gitmessages["Ssh Passphrase:"]}]
-								};
 								deferred.reject(error);
 								return;
 							}
@@ -533,15 +529,31 @@ define([
 				);
 				return deferred;
 			}
-		}, {
-			id: "orion.git.projecthandler",
-			type: "git",
+		};
+		provider.registerService("orion.project.handler", gitProjectHandlerImpl, {
+			id: "orion.git.filegitprojecthandler",
+			type: "git.filegit",
 			addParameters: [{id: "url", type: "url", name: gitmessages["Url:"]}],
-			optionalParameters: [{id: "sshuser", type: "text", name:  gitmessages["User Name:"]}, {id: "sshpassword", type: "password", name:  gitmessages["Password:"]},{id: "sshprivateKey", type: "textarea", name:  gitmessages["Ssh Private Key:"]}, {id: "sshpassphrase", type: "password", name:  gitmessages["Ssh Passphrase:"]}],
 			nls: "git/nls/gitmessages",
-			addDependencyName: gitmessages["addDependencyName"],
+			addDependencyName: "Git Repository (File/Git protocol)",
 			addDependencyTooltip: gitmessages["addDependencyTooltip"],
-			addProjectName: gitmessages["addProjectName"],
+			addProjectName: "Git Repository (File/Git protocol)",
+			addProjectTooltip: gitmessages["addProjectTooltip"],
+			actionComment: "Cloning ${url}",
+			validationProperties: [
+				{source: "Git"} // alternate {soruce: "Children:[Name]", match: ".git"}
+			]
+		});
+		provider.registerService("orion.project.handler", gitProjectHandlerImpl, {
+			id: "orion.git.httpsprojecthandler",
+			type: "git.https",
+			addParameters: [{id: "url", type: "url", name: gitmessages["Url:"]},
+			                {id: "sshuser", type: "text", name:  gitmessages["User Name:"]},
+			                {id: "sshpassword", type: "password", name:  gitmessages["Password:"]}],
+			nls: "git/nls/gitmessages",
+			addDependencyName: "Git Repository (Https protocol)",
+			addDependencyTooltip: gitmessages["addDependencyTooltip"],
+			addProjectName: "Git Repository (Https protocol)",
 			addProjectTooltip: gitmessages["addProjectTooltip"],
 			actionComment: "Cloning ${url}",
 			validationProperties: [

--- a/bundles/org.eclipse.orion.client.git/web/orion/git/gitCommands.js
+++ b/bundles/org.eclipse.orion.client.git/web/orion/git/gitCommands.js
@@ -551,27 +551,6 @@ var exports = {};
 					commandInvocation.errorData = jsonData.JsonData;
 					commandInvocation.errorData.failedOperation = jsonData.failedOperation;
 					commandService.collectParameters(commandInvocation);
-				} else if (!commandInvocation.optionsRequested){
-					var gitPreferenceStorage = new GitPreferenceStorage(serviceRegistry);
-					gitPreferenceStorage.isEnabled().then(
-						function(isEnabled){
-							if(isEnabled){
-								if (jsonData.JsonData.User)
-									commandInvocation.parameters = new mCommandRegistry.ParametersDescription([new mCommandRegistry.CommandParameter("sshpassword", "password", messages['Password:']), new mCommandRegistry.CommandParameter("saveCredentials", "boolean", messages["Don't prompt me again:"])], {hasOptionalParameters: true}); //$NON-NLS-3$ //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$
-								else
-									commandInvocation.parameters = new mCommandRegistry.ParametersDescription([new mCommandRegistry.CommandParameter("sshuser", "text", messages['User Name:']), new mCommandRegistry.CommandParameter("sshpassword", "password", messages['Password:']), new mCommandRegistry.CommandParameter("saveCredentials", "boolean", messages["Don't prompt me again:"])], {hasOptionalParameters: true}); //$NON-NLS-5$ //$NON-NLS-4$ //$NON-NLS-3$ //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$
-							} else {
-								if (jsonData.JsonData.User)
-									commandInvocation.parameters = new mCommandRegistry.ParametersDescription([new mCommandRegistry.CommandParameter("sshpassword", "password", messages['Password:'])], {hasOptionalParameters: true}); //$NON-NLS-1$ //$NON-NLS-0$
-								else
-									commandInvocation.parameters = new mCommandRegistry.ParametersDescription([new mCommandRegistry.CommandParameter("sshuser", "text", messages['User Name:']), new mCommandRegistry.CommandParameter("sshpassword", "password", messages['Password:'])], {hasOptionalParameters: true}); //$NON-NLS-4$ //$NON-NLS-3$ //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$
-							}
-							
-							commandInvocation.errorData = jsonData.JsonData;
-							commandInvocation.errorData.failedOperation = jsonData.failedOperation;
-							commandService.collectParameters(commandInvocation);
-						}
-					);
 				} else {
 					commandInvocation.errorData = jsonData.JsonData;
 					commandInvocation.errorData.failedOperation = jsonData.failedOperation;

--- a/bundles/org.eclipse.orion.client.git/web/orion/git/logic/gitCommon.js
+++ b/bundles/org.eclipse.orion.client.git/web/orion/git/logic/gitCommon.js
@@ -263,32 +263,10 @@ define(['orion/git/util','orion/i18nUtil','orion/git/gitPreferenceStorage','orio
 		}
 		
 		var failure = function(){
-			if (!data.parameters && !data.optionsRequested){
+			if (!data.firstFailure && !data.optionsRequested){
+				data.firstFailure = true;
 				triggerCallback(data.sshObject || {gitSshUsername: "", gitSshPassword: "", gitPrivateKey: "", gitPassphrase: ""}); //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$
 				return;
-			}
-		
-			// try to gather creds from the slideout first
-			if (data.parameters && !data.optionsRequested) {
-				var sshUser = (data.parameters && data.parameters.valueFor("sshuser")) || data.errorData.User; //$NON-NLS-0$
-				var sshPassword = data.parameters && data.parameters.valueFor("sshpassword") || "";	 //$NON-NLS-0$
-				var saveCredentials = data.parameters && data.parameters.valueFor("saveCredentials"); //$NON-NLS-0$
-				
-				var gitPreferenceStorage = new GitPreferenceStorage(serviceRegistry);
-				if(saveCredentials){
-					gitPreferenceStorage.put(repository, {
-						gitSshUsername : sshUser,
-						gitSshPassword : sshPassword
-					}).then(
-						function(){
-							triggerCallback({gitSshUsername: sshUser, gitSshPassword: sshPassword, gitPrivateKey: "", gitPassphrase: ""}); //$NON-NLS-0$
-						}
-					);
-					return;
-				} else {
-					triggerCallback({gitSshUsername: sshUser, gitSshPassword: sshPassword, gitPrivateKey: "", gitPassphrase: ""}); //$NON-NLS-0$
-					return;
-				}
 			}
 				
 			// use the old creds dialog
@@ -297,7 +275,9 @@ define(['orion/git/util','orion/i18nUtil','orion/git/gitPreferenceStorage','orio
 				serviceRegistry: serviceRegistry,
 				func: triggerCallback,
 				errordata: errorData,
-				closeCallback: closeCallback
+				closeCallback: closeCallback,
+				username: true,
+				password: true
 			});
 			
 			credentialsDialog.show();

--- a/bundles/org.eclipse.orion.client.git/web/orion/git/logic/gitPush.js
+++ b/bundles/org.eclipse.orion.client.git/web/orion/git/logic/gitPush.js
@@ -91,27 +91,6 @@ define([
 						commandInvocation.errorData = jsonData.JsonData;
 						commandInvocation.errorData.failedOperation = jsonData.failedOperation;
 						commandService.collectParameters(commandInvocation,sshSlideoutCloseCallback);
-					} else if (!commandInvocation.optionsRequested){
-						var gitPreferenceStorage = new GitPreferenceStorage(serviceRegistry);
-						gitPreferenceStorage.isEnabled().then(
-							function(isEnabled){
-								if(isEnabled){
-									if (jsonData.JsonData.User)
-										commandInvocation.parameters = new mCommandRegistry.ParametersDescription([new mCommandRegistry.CommandParameter("sshpassword", "password", messages['Password:']), new mCommandRegistry.CommandParameter("saveCredentials", "boolean", messages["Don't prompt me again:"])], {hasOptionalParameters: true}); //$NON-NLS-3$ //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$
-									else
-										commandInvocation.parameters = new mCommandRegistry.ParametersDescription([new mCommandRegistry.CommandParameter("sshuser", "text", messages['User Name:']), new mCommandRegistry.CommandParameter("sshpassword", "password", messages['Password:']), new mCommandRegistry.CommandParameter("saveCredentials", "boolean", messages["Don't prompt me again:"])], {hasOptionalParameters: true}); //$NON-NLS-5$ //$NON-NLS-4$ //$NON-NLS-3$ //$NON-NLS-2$ //$NON-NLS-1$ //$NON-NLS-0$
-								} else {
-									if (jsonData.JsonData.User)
-										commandInvocation.parameters = new mCommandRegistry.ParametersDescription([new mCommandRegistry.CommandParameter("sshpassword", "password", messages['Password:'])], {hasOptionalParameters: true}); //$NON-NLS-1$ //$NON-NLS-0$
-									else
-										commandInvocation.parameters = new mCommandRegistry.ParametersDescription([new mCommandRegistry.CommandParameter("sshuser", "text", messages['User Name:']), new mCommandRegistry.CommandParameter("sshpassword", "password", messages['Password:'])], {hasOptionalParameters: true}); //$NON-NLS-4$ //$NON-NLS-3$ //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-0$
-								}
-								
-								commandInvocation.errorData = jsonData.JsonData;
-								commandInvocation.errorData.failedOperation = jsonData.failedOperation;
-								commandService.collectParameters(commandInvocation,sshSlideoutCloseCallback);
-							}
-						);
 					} else {
 						commandInvocation.errorData = jsonData.JsonData;
 						commandInvocation.errorData.failedOperation = jsonData.failedOperation;

--- a/bundles/org.eclipse.orion.client.git/web/orion/git/widgets/GitCredentialsDialog.js
+++ b/bundles/org.eclipse.orion.client.git/web/orion/git/widgets/GitCredentialsDialog.js
@@ -39,7 +39,7 @@ define([ 'i18n!git/nls/gitmessages', 'orion/git/gitPreferenceStorage', 'orion/we
 	+ '<tr id="gitSshUsernameRow">' + '<td align="right"><label style="line-height: 1;" id="gitSshUsernameLabel" for="gitSshUsername">${Username:}</label></td>'
 			+ '<td><input id="gitSshUsername" type="text" value="" style="margin: 0;">' + '</td></tr>'
 
-			+ '<tr id="gitSshPasswordRow">' + '<td align="right"><input style = "margin: 0;" id="isSshPassword" type="radio" name="isSshPassword" checked value="password"/>'
+			+ '<tr id="gitSshPasswordRow">' + '<td align="right"><input style = "margin: 0; display: none" id="isSshPassword" type="radio" name="isSshPassword" checked value="password"/>'
 			+ '<label style="line-height: 1; margin-left: 5px; vertical-align: text-top;" id="gitSshPasswordLabel" for="gitSshPassword">${Password:}</label></td>'
 			+ '<td><input type="password" id="gitSshPassword" value="" style="margin: 0;">' + '</td></tr>'
 


### PR DESCRIPTION
-- deprecate support for ssh
-- communicate that https is the form of auth that
   we support
-- Orion does not store the password on disk, only
   in the lifespan of the page when the dialog is
   triggered. For example, navigating to the git
   page and then back will remove any "cache"
   (I'm using the term cache losely because
   the way the cache is used is Orion actually
   sets the value field of the parameter that it
   then uses to render the dialog box, that's why
   subsequent triggers of the dialog box shows the
   previously entered values).
-- Note that the password will appear as plaintext
   somewhere in js code (unsure whether this is
   even preventable, will follow up with Jason/Roger)
-- Note that we don't prevent a user entering an
   actual ssh url, it will just say "auth failed"
